### PR TITLE
Add support for various ssh ports for devices

### DIFF
--- a/aurora_cli/lib/cli_configuration.dart
+++ b/aurora_cli/lib/cli_configuration.dart
@@ -36,10 +36,11 @@ class Configuration {
         try {
           result.add({
             'ip': device['ip']!,
+            'port': (device['port'] ?? 22).toString(),
             'pass': device['pass']!,
           });
         } catch (e) {
-          print('Get dvices: $e');
+          print('Get devices: $e');
         }
       }
     }

--- a/aurora_cli/lib/commands_device.dart
+++ b/aurora_cli/lib/commands_device.dart
@@ -160,6 +160,8 @@ class CommandsDevice extends Command<int> {
       [
         '-i',
         device['ip']!,
+        '-p',
+        device['port']!,
       ],
     );
     return result.stderr.toString().isNotEmpty ? result.stderr : result.stdout;
@@ -175,6 +177,8 @@ class CommandsDevice extends Command<int> {
       [
         '-i',
         device['ip']!,
+        '-p',
+        device['port']!,
         '-c',
         argResults?['command'],
       ],

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -13,9 +13,11 @@ sign:
 
 ## Devices list
 ## devices:
-##  - ip - {device ip wifi or or cable connection}
+##  - ip: {device ip wifi or or cable connection}
+##    port: {optional ssh port which is used to connect to the device, default 22}
 ##    pass: {password in device for devel-su}
 ##
 devices:
-  - ip: '192.168.2.15'
+  - ip: 192.168.2.15
+    port: 22
     pass: '00000'

--- a/scripts/device_command.sh
+++ b/scripts/device_command.sh
@@ -12,9 +12,10 @@ fi
 
 ## Get params keys
 
-while getopts i:c: flag; do
+while getopts i:p:c: flag; do
   case "${flag}" in
   i) ip=${OPTARG} ;;
+  p) port=${OPTARG} ;;
   c) command=${OPTARG} ;;
   *)
     echo "usage: $0 [-i] [-c]" >&2
@@ -25,9 +26,9 @@ done
 
 ## Check params keys
 
-if [ -z "$ip" ] ||  [ -z "$command" ]; then
-  echo "Specify ip device and command!"
+if [ -z "$ip" ] || [ -z "$port" ] ||  [ -z "$command" ]; then
+  echo "Specify device ip, port and command!"
   exit 1
 fi
 
-ssh defaultuser@"$ip" "$command"
+ssh -p "$port" defaultuser@"$ip" "$command"

--- a/scripts/device_ssh_copy.sh
+++ b/scripts/device_ssh_copy.sh
@@ -12,9 +12,10 @@ fi
 
 ## Get params keys
 
-while getopts i: flag; do
+while getopts i:p: flag; do
   case "${flag}" in
   i) ip=${OPTARG} ;;
+  p) port=${OPTARG} ;;
   *)
     echo "usage: $0 [-i]" >&2
     exit 1
@@ -24,9 +25,9 @@ done
 
 ## Check params keys
 
-if [ -z "$ip" ]; then
-  echo "Specify ip device!"
+if [ -z "$ip" ] || [ -z "$port" ]; then
+  echo "Specify device ip and port!"
   exit 1
 fi
 
-ssh-copy-id defaultuser@"$ip"
+ssh-copy-id -p "$port" defaultuser@"$ip"


### PR DESCRIPTION
On some devices, such as emulators, the port for connecting to the device is not standard (22). This commit adds the ability to specify the ssh port for each device.